### PR TITLE
Tensorly refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,543 @@
-*.DS_Store
-*__pycache__
-.idea
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,visualstudiocode,macos,linux,latex
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,jupyternotebooks,visualstudiocode,macos,linux,latex
+
+### JupyterNotebooks ###
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+
+### LaTeX ###
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+*.slg
+*.slo
+*.sls
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
+# gnuplot
+*.gnuplot
+*.table
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.glog
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# newpax
+*.newpax
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# svg
+svg-inkscape/
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# titletoc
+*.ptc
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# TeXnicCenter
+*.tps
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz
+
+# xwatermark package
+*.xwm
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib
+
+### LaTeX Patch ###
+# LIPIcs / OASIcs
+*.vtc
+
+# glossaries
+*.glstex
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+
+# End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,visualstudiocode,macos,linux,latex

--- a/repsim/__init__.py
+++ b/repsim/__init__.py
@@ -1,4 +1,4 @@
-import torch
+import tensorly as tl
 from repsim.util import CorrType
 from repsim.compare_impl import (
     BaseRepSim,
@@ -11,11 +11,11 @@ from typing import Union
 
 
 def compare(
-    x: torch.Tensor,
-    y: torch.Tensor,
+    x: tl.tensor,
+    y: tl.tensor,
     method: Union[BaseRepSim, str] = "stress",
     **kwargs,
-) -> torch.Tensor:
+) -> tl.tensor:
     method_lookup = {
         "stress": Stress(),
         "generalized_shape_metric": GeneralizedShapeMetric(),

--- a/repsim/compare_impl.py
+++ b/repsim/compare_impl.py
@@ -1,9 +1,12 @@
 import tensorly as tl
+import numpy as np
 from repsim.kernels import Kernel, center, Linear
 from repsim import pairwise
 from repsim.util import upper_triangle, corrcoef
 from repsim.util import MetricType, CompareType, CorrType
 from typing import Union
+
+e = np.e
 
 
 class BaseRepSim(object):
@@ -53,7 +56,7 @@ class GeneralizedShapeMetric(BaseRepSim):
         rsm_x = pairwise.compare(x, type=CompareType.INNER_PRODUCT, kernel=kernel_x)
         rsm_y = pairwise.compare(y, type=CompareType.INNER_PRODUCT, kernel=kernel_y)
         # Note: use clipping in case of numerical imprecision. arccos(1.00000000001) will give NaN!
-        return tl.arccos(tl.clip(cka(rsm_x, rsm_y), -1.0, 1.0))
+        return np.arccos(tl.clip(cka(rsm_x, rsm_y), -1.0, 1.0))
 
 
 class Stress(BaseRepSim):
@@ -165,7 +168,8 @@ class AffineInvariantRiemannian(BaseRepSim):
         rsm_y -= self._shrink * off_diag_n * rsm_y
         # Compute rsm_x^{-1} @ rsm_y
         x_inv_y = tl.solve(rsm_x, rsm_y)
-        log_eigs = tl.log(tl.eigh(x_inv_y)[0].real)
+        eigs = tl.eigh(x_inv_y)[0].real
+        log_eigs = tl.log2(eigs) / tl.log2(e)
         return tl.sqrt(tl.sum(log_eigs**2))
 
 

--- a/repsim/kernels/__init__.py
+++ b/repsim/kernels/__init__.py
@@ -1,5 +1,3 @@
-import torch
-
 from .kernel_base import Kernel, center
 from .radial import SquaredExponential, Laplace
 from .linear import Linear

--- a/repsim/kernels/kernel_base.py
+++ b/repsim/kernels/kernel_base.py
@@ -1,8 +1,8 @@
-import torch
 from typing import Union, Iterable
+import tensorly as tl
 
 
-def center(k: torch.Tensor) -> torch.Tensor:
+def center(k: tl.tensor) -> tl.tensor:
     """Center features of a kernel by pre- and post-multiplying by the centering matrix H.
 
     In other words, if k_ij is dot(x_i, x_j), the result will be dot(x_i - mu_x, x_j - mu_x).
@@ -16,16 +16,14 @@ def center(k: torch.Tensor) -> torch.Tensor:
             f"Expected k to be nxn square matrix, but it has size {k.size()}"
         )
     H = (
-        torch.eye(n, device=k.device, dtype=k.dtype)
-        - torch.ones((n, n), device=k.device, dtype=k.dtype) / n
+        tl.eye(n, device=k.device, dtype=k.dtype)
+        - tl.ones((n, n), device=k.device, dtype=k.dtype) / n
     )
     return H @ k @ H
 
 
 class Kernel(object):
-    def __call__(
-        self, x: torch.Tensor, y: Union[None, torch.Tensor] = None
-    ) -> torch.Tensor:
+    def __call__(self, x: tl.tensor, y: Union[None, tl.tensor] = None) -> tl.tensor:
         if y is None:
             y = x
 
@@ -34,7 +32,7 @@ class Kernel(object):
 
         return self._call_impl(x, y)
 
-    def _call_impl(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    def _call_impl(self, x: tl.tensor, y: tl.tensor) -> tl.tensor:
         raise NotImplementedError("Kernel._call_impl must be implemented by a subclass")
 
 
@@ -43,12 +41,10 @@ class SumKernel(Kernel):
         super(SumKernel, self).__init__()
         self.kernels = list(kernels)
         self.weights = (
-            torch.tensor(weights)
-            if weights is not None
-            else torch.ones(len(self.kernels))
+            tl.tensor(weights) if weights is not None else tl.ones(len(self.kernels))
         )
 
-    def _call_impl(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    def _call_impl(self, x: tl.tensor, y: tl.tensor) -> tl.tensor:
         tot = self.weights[0] * self.kernels[0](x, y)
         for w, k in zip(self.weights[1:], self.kernels[1:]):
             tot += k(x, y) * w

--- a/repsim/kernels/length_scale.py
+++ b/repsim/kernels/length_scale.py
@@ -1,11 +1,11 @@
-import torch
+import tensorly as tl
 from repsim.util import pdist2, upper_triangle
 
 
-def median_euclidean(x: torch.Tensor, y=None, fraction=1.0):
+def median_euclidean(x: tl.tensor, y=None, fraction=1.0):
     if y is None:
         # Compare rows of x to other rows of x
-        return fraction * torch.sqrt(torch.median(upper_triangle(pdist2(x, x))))
+        return fraction * tl.sqrt(tl.median(upper_triangle(pdist2(x, x))))
     else:
         # Compare x to y
-        return fraction * torch.sqrt(torch.median(pdist2(x, y)))
+        return fraction * tl.sqrt(tl.median(pdist2(x, y)))

--- a/repsim/kernels/length_scale.py
+++ b/repsim/kernels/length_scale.py
@@ -1,11 +1,12 @@
 import tensorly as tl
+import numpy as np
 from repsim.util import pdist2, upper_triangle
 
 
 def median_euclidean(x: tl.tensor, y=None, fraction=1.0):
     if y is None:
         # Compare rows of x to other rows of x
-        return fraction * tl.sqrt(tl.median(upper_triangle(pdist2(x, x))))
+        return fraction * tl.sqrt(np.median(upper_triangle(pdist2(x, x))))
     else:
         # Compare x to y
-        return fraction * tl.sqrt(tl.median(pdist2(x, y)))
+        return fraction * tl.sqrt(np.median(pdist2(x, y)))

--- a/repsim/kernels/linear.py
+++ b/repsim/kernels/linear.py
@@ -1,7 +1,7 @@
-import torch
+import tensorly as tl
 from .kernel_base import Kernel
 
 
 class Linear(Kernel):
-    def _call_impl(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        return torch.einsum("nd,md->nm", x, y)
+    def _call_impl(self, x: tl.tensor, y: tl.tensor) -> tl.tensor:
+        return tl.einsum("nd,md->nm", x, y)

--- a/repsim/kernels/radial.py
+++ b/repsim/kernels/radial.py
@@ -1,4 +1,4 @@
-import torch
+import tensorly as tl
 from .kernel_base import Kernel
 from .length_scale import median_euclidean
 from repsim.util import pdist2
@@ -12,13 +12,13 @@ class SquaredExponential(Kernel):
     def set_scale(self, lengh_scale):
         self._scale = lengh_scale
 
-    def _call_impl(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    def _call_impl(self, x: tl.tensor, y: tl.tensor) -> tl.tensor:
         if type(self._scale) is str and self._scale == "auto":
             sc = median_euclidean(x)
         else:
             sc = self._scale
 
-        return torch.exp(-pdist2(x, y) / sc**2)
+        return tl.exp(-pdist2(x, y) / sc**2)
 
 
 class Laplace(Kernel):
@@ -29,10 +29,10 @@ class Laplace(Kernel):
     def set_scale(self, lengh_scale):
         self._scale = lengh_scale
 
-    def _call_impl(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    def _call_impl(self, x: tl.tensor, y: tl.tensor) -> tl.tensor:
         if type(self._scale) is str and self._scale == "auto":
             sc = median_euclidean(x)
         else:
             sc = self._scale
 
-        return torch.exp(-torch.sqrt(pdist2(x, y)) / sc)
+        return tl.exp(-tl.sqrt(pdist2(x, y)) / sc)

--- a/repsim/kernels/radial.py
+++ b/repsim/kernels/radial.py
@@ -2,6 +2,7 @@ import tensorly as tl
 from .kernel_base import Kernel
 from .length_scale import median_euclidean
 from repsim.util import pdist2
+import numpy as np
 
 
 class SquaredExponential(Kernel):
@@ -18,7 +19,7 @@ class SquaredExponential(Kernel):
         else:
             sc = self._scale
 
-        return tl.exp(-pdist2(x, y) / sc**2)
+        return np.exp(-pdist2(x, y) / sc**2)
 
 
 class Laplace(Kernel):
@@ -35,4 +36,4 @@ class Laplace(Kernel):
         else:
             sc = self._scale
 
-        return tl.exp(-tl.sqrt(pdist2(x, y)) / sc)
+        return np.exp(-tl.sqrt(pdist2(x, y)) / sc)

--- a/repsim/pairwise/__init__.py
+++ b/repsim/pairwise/__init__.py
@@ -1,15 +1,15 @@
-import torch
+import tensorly as tl
 from repsim import kernels
 from repsim.util import CompareType
 from typing import Union
 
 
 def compare(
-    x: torch.Tensor,
+    x: tl.tensor,
     *,
     type: CompareType = CompareType.INNER_PRODUCT,
     kernel: Union[None, kernels.Kernel] = None
-) -> torch.Tensor:
+) -> tl.tensor:
     """Compute n by n pairwise distance (or similarity) between all pairs of rows of x.
 
     :param x: n by d matrix of data.
@@ -27,21 +27,21 @@ def compare(
     if type == CompareType.INNER_PRODUCT:
         return inner_product
     elif type == CompareType.ANGLE:
-        diag = torch.diag(inner_product)
+        diag = tl.diag(inner_product)
         norm_inner_product = (
-            inner_product / torch.sqrt(diag[:, None]) / torch.sqrt(diag[None, :])
+            inner_product / tl.sqrt(diag[:, None]) / tl.sqrt(diag[None, :])
         )
         # Note: floating point instability might result in norm_inner_product being outside [-1, 1]. This results in
         # NaN angles unless we clip:
-        return torch.arccos(torch.clip(norm_inner_product, -1.0, +1.0))
+        return tl.arccos(tl.clip(norm_inner_product, -1.0, +1.0))
     elif type == CompareType.SQUARE_DISTANCE:
-        self_sim = torch.diag(inner_product)
+        self_sim = tl.diag(inner_product)
         # Using that (x_i - x_j)*(x_i - x_j) = x_i*x_i + x_j*x_j - 2*x_i*x_j
         return self_sim[:, None] + self_sim[None, :] - 2 * inner_product
     elif type == CompareType.DISTANCE:
-        self_sim = torch.diag(inner_product)
+        self_sim = tl.diag(inner_product)
         # See above
-        return torch.sqrt(self_sim[:, None] + self_sim[None, :] - 2 * inner_product)
+        return tl.sqrt(self_sim[:, None] + self_sim[None, :] - 2 * inner_product)
 
 
 __all__ = ["compare"]

--- a/repsim/pairwise/__init__.py
+++ b/repsim/pairwise/__init__.py
@@ -1,7 +1,8 @@
+from typing import Union
 import tensorly as tl
+import numpy as np
 from repsim import kernels
 from repsim.util import CompareType
-from typing import Union
 
 
 def compare(
@@ -33,7 +34,7 @@ def compare(
         )
         # Note: floating point instability might result in norm_inner_product being outside [-1, 1]. This results in
         # NaN angles unless we clip:
-        return tl.arccos(tl.clip(norm_inner_product, -1.0, +1.0))
+        return np.arccos(tl.clip(norm_inner_product, -1.0, +1.0))
     elif type == CompareType.SQUARE_DISTANCE:
         self_sim = tl.diag(inner_product)
         # Using that (x_i - x_j)*(x_i - x_j) = x_i*x_i + x_j*x_j - 2*x_i*x_j

--- a/repsim/test_compare.py
+++ b/repsim/test_compare.py
@@ -1,12 +1,13 @@
-import torch
+import tensorly as tl
 from repsim import compare
 from repsim.kernels import Linear, Laplace, SquaredExponential
 from repsim.compare_impl import AffineInvariantRiemannian
 import pytest
+import numpy as np
 
 
 def test_compare_random_data():
-    x, y = torch.randn(10, 4), torch.randn(10, 3)
+    x, y = tl.randn(10, 4), tl.randn(10, 3)
     methods = [
         "stress",
         "generalized_shape_metric",
@@ -19,16 +20,16 @@ def test_compare_random_data():
         for meth in methods:
             val_xy = compare(x, y, method=meth, kernel_x=k, kernel_y=k)
             val_yx = compare(y, x, method=meth, kernel_x=k, kernel_y=k)
-            assert not torch.isnan(val_yx) and not torch.isnan(
+            assert not np.isnan(val_yx) and not np.isnan(
                 val_xy
             ), f"NaN value in compare() using method {meth} and kernel {k}"
-            assert torch.isclose(
+            assert np.isclose(
                 val_yx, val_xy, rtol=1e-3
             ), f"Asymmetry in comparison using method {meth} and kernel {k}: {val_yx.item()} vs {val_xy.item()}"
 
 
 def test_riemmannian_rank_deficient():
-    x, y = torch.randn(10, 4), torch.randn(10, 3)
+    x, y = tl.randn(10, 4), tl.randn(10, 3)
     unregularized = AffineInvariantRiemannian(shrinkage=0.0)
     # We expect the unregularized method to fail when x,y have more rows than columns.
     # (Note that in @test_compare_random_data above, specifying method="riemannian" defaults to a regularized version)

--- a/repsim/test_pairwise.py
+++ b/repsim/test_pairwise.py
@@ -1,25 +1,24 @@
-import torch
+import tensorly as tl
 from repsim import pairwise
 from repsim.kernels import Linear, SquaredExponential, Laplace
 from repsim.util import CompareType, upper_triangle
+import numpy as np
 
 
 def test_pairwise_compare_random_data():
-    x = torch.randn(10, 3)
+    x = tl.randn(10, 3)
     kernels = [None, Linear(), SquaredExponential(), Laplace()]
     for k in kernels:
         for cmp in CompareType:
             xx = pairwise.compare(x, type=cmp, kernel=k)
-            assert not torch.any(
-                torch.isnan(xx)
+            assert not np.any(
+                np.isnan(xx)
             ), f"NaN value in pairwise comparison using {cmp}!"
-            assert torch.allclose(
-                xx, xx.T
-            ), f"Asymmetric pairwise comparison using {cmp}"
+            assert np.allclose(xx, xx.T), f"Asymmetric pairwise comparison using {cmp}"
 
 
 def test_upper_triangle():
-    A = torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-    assert torch.all(upper_triangle(A) == torch.tensor([1, 2, 5]))
-    assert torch.all(upper_triangle(A, offset=0) == torch.tensor([0, 1, 2, 4, 5, 8]))
-    assert torch.all(upper_triangle(A, offset=2) == torch.tensor([2]))
+    A = tl.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    assert tl.all(upper_triangle(A) == tl.tensor([1, 2, 5]))
+    assert tl.all(upper_triangle(A, offset=0) == tl.tensor([0, 1, 2, 4, 5, 8]))
+    assert tl.all(upper_triangle(A, offset=2) == tl.tensor([2]))

--- a/repsim/util.py
+++ b/repsim/util.py
@@ -75,7 +75,7 @@ def upper_triangle(A: tl.tensor, offset=1) -> tl.tensor:
     if (A.ndim != 2) or (A.size()[0] != A.size()[1]):
         raise ValueError("A must be square")
 
-    i, j = np.triu_indices(*A.size(), offset=offset, device=A.device)
+    i, j = np.triu_indices(*A.size(), offset)
     return A[i, j]
 
 

--- a/repsim/util.py
+++ b/repsim/util.py
@@ -1,5 +1,6 @@
-import torch
+import tensorly as tl
 import enum
+import numpy as np
 
 
 class CompareType(enum.Enum):
@@ -47,7 +48,7 @@ class CorrType(enum.Enum):
     SPEARMAN = 2
 
 
-def pdist2(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+def pdist2(x: tl.tensor, y: tl.tensor) -> tl.tensor:
     """Compute squared pairwise distances (x-y)*(x-y)
 
     :param x: n by d matrix of d-dimensional values
@@ -57,41 +58,41 @@ def pdist2(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     n, d = x.size()
     if y.size()[-1] != d:
         raise ValueError("x and y must have same second dimension")
-    xx = torch.sum(x * x, dim=1)
-    yy = torch.sum(y * y, dim=1)
-    xy = torch.einsum("nd,md->nm", x, y)
+    xx = tl.sum(x * x, dim=1)
+    yy = tl.sum(y * y, dim=1)
+    xy = tl.einsum("nd,md->nm", x, y)
     # Using (x-y)*(x-y) = x*x + y+y - 2*x*y, and clipping in [0, inf) just in case of numerical imprecision
-    return torch.clip(xx[:, None] + yy[None, :] - 2 * xy, 0.0, None)
+    return tl.clip(xx[:, None] + yy[None, :] - 2 * xy, 0.0, None)
 
 
-def upper_triangle(A: torch.Tensor, offset=1) -> torch.Tensor:
+def upper_triangle(A: tl.tensor, offset=1) -> tl.tensor:
     """Get the upper-triangular elements of a square matrix.
 
     :param A: square matrix
     :param offset: number of diagonals to exclude, including the main diagonal. Deafult is 1.
-    :return: a 1-dimensional torch Tensor containing upper-triangular values of A
+    :return: a 1-dimensional tl Tensor containing upper-triangular values of A
     """
     if (A.ndim != 2) or (A.size()[0] != A.size()[1]):
         raise ValueError("A must be square")
 
-    i, j = torch.triu_indices(*A.size(), offset=offset, device=A.device)
+    i, j = np.triu_indices(*A.size(), offset=offset, device=A.device)
     return A[i, j]
 
 
 def corrcoef(
-    a: torch.Tensor, b: torch.Tensor, type: CorrType = CorrType.PEARSON
-) -> torch.Tensor:
+    a: tl.tensor, b: tl.tensor, type: CorrType = CorrType.PEARSON
+) -> tl.tensor:
     """Correlation coefficient between two vectors.
 
-    :param a: a 1-dimensional torch.Tensor of values
-    :param b: a 1-dimensional torch.Tensor of values
+    :param a: a 1-dimensional tl.tensor of values
+    :param b: a 1-dimensional tl.tensor of values
     :return: correlation between a and b
     """
     if type == CorrType.PEARSON:
         z_a = (a - a.mean()) / a.std(dim=-1)
         z_b = (b - b.mean()) / b.std(dim=-1)
-        return torch.sum(z_a * z_b)
+        return tl.sum(z_a * z_b)
     elif type == CorrType.SPEARMAN:
         return corrcoef(
-            torch.argsort(a).float(), torch.argsort(b).float(), type=CorrType.PEARSON
+            tl.argsort(a).float(), tl.argsort(b).float(), type=CorrType.PEARSON
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # tensorly>=0.7.0
-git+git://github.com/tensorly/tensorly.git
+git+https://github.com/tensorly/tensorly.git@master#egg=tensorly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-torch>=1.11.0
-numpy>=1.19.3
+tensorly>=0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-tensorly>=0.7.0
+# tensorly>=0.7.0
+git+git://github.com/tensorly/tensorly.git


### PR DESCRIPTION
So far, have just added simple method-rename refactors.

There are a few silly outstanding changes (tensorly doesn't have a `log` function right now, and eigvals are computed alongside eigvecs and then we throw away the vecs...) that I will hit next.

- [x] simple rename refactors
- [x] replace log call with `log2(x)/log2(e)` 
- [ ] Fix exp and arccos missing methods

Missing methods are:
* `exp` (https://github.com/tensorly/tensorly/pull/377)
* `log` (https://github.com/tensorly/tensorly/pull/381)
* `arccos` (no current tensorly implementation)
* `triu_indices` (no current tensorly implementation)

In tests we also use `isnan` and `isclose`, but for our purposes I fall back on numpy since this is just for testing.