### PR TITLE
Add Space#geodesic_from signature

### DIFF
--- a/repsim/geometry/geodesic.py
+++ b/repsim/geometry/geodesic.py
@@ -92,9 +92,6 @@ def point_along(pt_a: Point,
     if frac < 0. or frac > 1.:
         raise ValueError(f"'frac' must be in [0, 1] but is {frac}")
 
-    if space._has_implemented_closed_form_geodesic():
-        return space.geodesic_from(pt_a, pt_b, frac)
-
     # Three cases where we can just break early without optimizing
     if frac == 0.:
         return pt_a, OptimResult.CONVERGED
@@ -102,6 +99,11 @@ def point_along(pt_a: Point,
         return pt_b, OptimResult.CONVERGED
     elif torch.allclose(pt_a, pt_b, atol=kwargs.get('pt_tol', 1e-6)):
         return space.project((pt_a+pt_b)/2), OptimResult.CONVERGED
+    
+    # We can also use a closed-form geodesic computation from the space itself
+    # if one is available.
+    if space._has_implemented_closed_form_geodesic():
+        return space.geodesic_from(pt_a, pt_b, frac)
 
     # For reference, we know we're on the geodesic when dist_ap + dist_pb = dist_ab
     # dist_ab = space.length(pt_a, pt_b)

--- a/repsim/geometry/geodesic.py
+++ b/repsim/geometry/geodesic.py
@@ -92,6 +92,9 @@ def point_along(pt_a: Point,
     if frac < 0. or frac > 1.:
         raise ValueError(f"'frac' must be in [0, 1] but is {frac}")
 
+    if space._has_implemented_closed_form_geodesic():
+        return space.geodesic_from(pt_a, pt_b, frac)
+
     # Three cases where we can just break early without optimizing
     if frac == 0.:
         return pt_a, OptimResult.CONVERGED
@@ -101,7 +104,7 @@ def point_along(pt_a: Point,
         return space.project((pt_a+pt_b)/2), OptimResult.CONVERGED
 
     # For reference, we know we're on the geodesic when dist_ap + dist_pb = dist_ab
-    dist_ab = space.length(pt_a, pt_b)
+    # dist_ab = space.length(pt_a, pt_b)
 
     # Default initial guess to projection of euclidean interpolated point
     pt = space.project(guess) if guess is not None else space.project((1-frac)*pt_a + frac*pt_b)

--- a/repsim/geometry/geodesic.py
+++ b/repsim/geometry/geodesic.py
@@ -93,17 +93,17 @@ def point_along(pt_a: Point,
         raise ValueError(f"'frac' must be in [0, 1] but is {frac}")
 
     # Three cases where we can just break early without optimizing
-    if frac == 0.:
-        return pt_a, OptimResult.CONVERGED
-    elif frac == 1.:
-        return pt_b, OptimResult.CONVERGED
+    if frac == 0:
+        return pt_a, OptimResult.NO_OPT_NEEDED
+    elif frac == 1:
+        return pt_b, OptimResult.NO_OPT_NEEDED
     elif torch.allclose(pt_a, pt_b, atol=kwargs.get('pt_tol', 1e-6)):
-        return space.project((pt_a+pt_b)/2), OptimResult.CONVERGED
+        return space.project((pt_a+pt_b)/2), OptimResult.NO_OPT_NEEDED
     
     # We can also use a closed-form geodesic computation from the space itself
     # if one is available.
     if space._has_implemented_closed_form_geodesic():
-        return space.geodesic_from(pt_a, pt_b, frac)
+        return space.geodesic_from(pt_a, pt_b, frac), OptimResult.NO_OPT_NEEDED
 
     # For reference, we know we're on the geodesic when dist_ap + dist_pb = dist_ab
     # dist_ab = space.length(pt_a, pt_b)

--- a/repsim/geometry/manifold.py
+++ b/repsim/geometry/manifold.py
@@ -48,6 +48,16 @@ class Manifold(object):
 
     def _length(self, pt_a: Point, pt_b: Point) -> Scalar:
         raise NotImplementedError("_length() must be implemented by a subclass")
+    
+    def _has_implemented_closed_form_geodesic(self) -> bool:
+        """
+        Check if there is an implementation of a closed-form geodesic for
+        this space.
+        """
+        return False
+    
+    def geodesic_from(self, pt_a: Point, pt_b: Point, frac: float = 0.5):
+        raise NotImplementedError(f"{self} does not have an implemented closed-form geodesic. (Check {self}._has_implemented_closed_form_geodesic())")
 
 
 class HyperSphere(Manifold):

--- a/repsim/geometry/manifold.py
+++ b/repsim/geometry/manifold.py
@@ -50,9 +50,7 @@ class Manifold(object):
         raise NotImplementedError("_length() must be implemented by a subclass")
     
     def _has_implemented_closed_form_geodesic(self) -> bool:
-        """
-        Check if there is an implementation of a closed-form geodesic for
-        this space.
+        """Check if there is an implementation of a closed-form geodesic for this space.
         """
         return False
     

--- a/repsim/geometry/optimize.py
+++ b/repsim/geometry/optimize.py
@@ -8,6 +8,7 @@ class OptimResult(enum.Enum):
     CONVERGED = 0
     MAX_STEPS_REACHED = 1
     CONDITIONS_VIOLATED = 2
+    NO_OPT_NEEDED = 0
 
 
 def minimize(fun: Callable[[Point], Scalar],
@@ -29,7 +30,7 @@ def minimize(fun: Callable[[Point], Scalar],
     fval, grad = fn_wrapper(pt)
     for itr in range(max_iter):
         # Update by gradient descent + line search
-        step_direction = -grad
+        step_direction = -1 * grad
         new_pt = space.project(pt.detach() + step_size * step_direction)
         new_fval, new_grad = fn_wrapper(new_pt)
 

--- a/repsim/geometry/trig.py
+++ b/repsim/geometry/trig.py
@@ -25,16 +25,28 @@ def slerp(
     """
     assert frac >= 0.0 and frac <= 1.0, "frac must be between 0 and 1"
 
-    # ab = torch.matmul(pt_a, pt_b)
-    # dot of the ravels:
-    ab = torch.dot(pt_a.view(-1), pt_b.view(-1))
-    # omega = torch.acos(torch.clamp(ab, -1.0, 1.0))
-    omega = torch.acos(ab)
-    print("F", pt_a.view(-1), pt_b.view(-1), ab, omega)
-    pt_a_frac = pt_a * torch.sin((1 - frac) * omega) / torch.sin(omega)
-    pt_b_frac = pt_b * torch.sin(frac * omega) / torch.sin(omega)
-    n = (pt_a_frac + pt_b_frac).reshape(pt_a.shape)
+    a = pt_a
+    b = pt_b
+    ab = torch.matmul(a, b)
+    omega = torch.acos(torch.clamp(ab, -1.0, 1.0))
+    a_frac = a * torch.sin((1 - frac) * omega) / torch.sin(omega)
+    b_frac = b * torch.sin(frac * omega) / torch.sin(omega)
+    n = (a_frac + b_frac).reshape(a.shape)
     return n
+
+
+# def slerp(start, end, val):
+#     a = start / torch.norm(start)
+#     b = end / torch.norm(end)
+#     a = torch.tensor([a])
+#     b = torch.tensor([b])
+#     omega = torch.acos(torch.clamp(torch.matmul(a, b.t()), -1, 1))
+#     so = torch.sin(omega)
+#     if so == 0:
+#         return (1.0 - val) * start + val * end  # L'Hopital's rule / LERP
+#     return (
+#         torch.sin((1.0 - val) * omega) / so * start + torch.sin(val * omega) / so * end
+#     )
 
 
 def angle(pt_a: Point, pt_b: Point, pt_c: Point, space: Manifold, **kwargs) -> Scalar:

--- a/repsim/geometry/trig.py
+++ b/repsim/geometry/trig.py
@@ -14,6 +14,8 @@ def slerp(
 
     https://en.m.wikipedia.org/wiki/Slerp
 
+    The interpolated point will always have unit norm.
+
     Arguments:
         pt_a (Point): First point.
         pt_b (Point): Second point.
@@ -23,7 +25,7 @@ def slerp(
         Point: The slerp between pt_a and pt_b.
 
     """
-    assert frac >= 0.0 and frac <= 1.0, "frac must be between 0 and 1"
+    assert 0.0 <= frac <= 1.0, "frac must be between 0 and 1"
 
     a = pt_a
     b = pt_b

--- a/repsim/geometry/trig.py
+++ b/repsim/geometry/trig.py
@@ -31,11 +31,13 @@ def slerp(
     a = pt_a / torch.sqrt(torch.sum(pt_a * pt_a))
     b = pt_b / torch.sqrt(torch.sum(pt_b * pt_b))
 
-    # Check cases where we can break early
+    # Check cases where we can break early (and doing so avoids things like divide-by-zero later!)
     if frac == 0.0:
         return a
     elif frac == 1.0:
         return b
+    elif torch.allclose(a, b):
+        return (a + b) / 2
 
     # Get 'omega' - the angle between a and b
     ab = torch.sum(a*b)

--- a/repsim/geometry/trig.py
+++ b/repsim/geometry/trig.py
@@ -25,10 +25,16 @@ def slerp(
     """
     assert frac >= 0.0 and frac <= 1.0, "frac must be between 0 and 1"
 
-    omega = torch.acos(torch.clamp(torch.matmul(pt_a, pt_b), -1.0, 1.0))
-    pt_a_frac = torch.sin((1 - frac) * omega) / torch.sin(omega) * pt_a
-    pt_b_frac = torch.sin(frac * omega) / torch.sin(omega) * pt_b
-    return pt_a_frac + pt_b_frac
+    # ab = torch.matmul(pt_a, pt_b)
+    # dot of the ravels:
+    ab = torch.dot(pt_a.view(-1), pt_b.view(-1))
+    # omega = torch.acos(torch.clamp(ab, -1.0, 1.0))
+    omega = torch.acos(ab)
+    print("F", pt_a.view(-1), pt_b.view(-1), ab, omega)
+    pt_a_frac = pt_a * torch.sin((1 - frac) * omega) / torch.sin(omega)
+    pt_b_frac = pt_b * torch.sin(frac * omega) / torch.sin(omega)
+    n = (pt_a_frac + pt_b_frac).reshape(pt_a.shape)
+    return n
 
 
 def angle(pt_a: Point, pt_b: Point, pt_c: Point, space: Manifold, **kwargs) -> Scalar:

--- a/repsim/geometry/trig.py
+++ b/repsim/geometry/trig.py
@@ -35,20 +35,6 @@ def slerp(
     return n
 
 
-# def slerp(start, end, val):
-#     a = start / torch.norm(start)
-#     b = end / torch.norm(end)
-#     a = torch.tensor([a])
-#     b = torch.tensor([b])
-#     omega = torch.acos(torch.clamp(torch.matmul(a, b.t()), -1, 1))
-#     so = torch.sin(omega)
-#     if so == 0:
-#         return (1.0 - val) * start + val * end  # L'Hopital's rule / LERP
-#     return (
-#         torch.sin((1.0 - val) * omega) / so * start + torch.sin(val * omega) / so * end
-#     )
-
-
 def angle(pt_a: Point, pt_b: Point, pt_c: Point, space: Manifold, **kwargs) -> Scalar:
     """
     Angle B of triangle ABC, based on incident angle of geodesics AB and CB.

--- a/repsim/geometry/trig.py
+++ b/repsim/geometry/trig.py
@@ -27,14 +27,23 @@ def slerp(
     """
     assert 0.0 <= frac <= 1.0, "frac must be between 0 and 1"
 
-    a = pt_a
-    b = pt_b
-    ab = torch.matmul(a, b)
-    omega = torch.acos(torch.clamp(ab, -1.0, 1.0))
+    # Normalize a and b to unit vectors
+    a = pt_a / torch.sqrt(torch.sum(pt_a * pt_a))
+    b = pt_b / torch.sqrt(torch.sum(pt_b * pt_b))
+
+    # Check cases where we can break early
+    if frac == 0.0:
+        return a
+    elif frac == 1.0:
+        return b
+
+    # Get 'omega' - the angle between a and b
+    ab = torch.sum(a*b)
+    omega = torch.acos(torch.clip(ab, -1.0, 1.0))
+    # Do interpolation using the SLERP formula
     a_frac = a * torch.sin((1 - frac) * omega) / torch.sin(omega)
     b_frac = b * torch.sin(frac * omega) / torch.sin(omega)
-    n = (a_frac + b_frac).reshape(a.shape)
-    return n
+    return (a_frac + b_frac).reshape(a.shape)
 
 
 def angle(pt_a: Point, pt_b: Point, pt_c: Point, space: Manifold, **kwargs) -> Scalar:

--- a/repsim/geometry/trig.py
+++ b/repsim/geometry/trig.py
@@ -4,21 +4,50 @@ from repsim.geometry.geodesic import point_along
 import warnings
 
 
-def angle(pt_a: Point,
-          pt_b: Point,
-          pt_c: Point,
-          space: Manifold,
-          **kwargs) -> Scalar:
-    """Angle B of triangle ABC, based on incident angle of geodesics AB and CB. If B is along the geodesic from A to C,
-    then the angle is pi (180 degrees). If A=C, then the angle is zero.
+def slerp(
+    pt_a: Point,
+    pt_b: Point,
+    frac: float,
+) -> Point:
+    """
+    Arc slerp between two points.
+
+    https://en.m.wikipedia.org/wiki/Slerp
+
+    Arguments:
+        pt_a (Point): First point.
+        pt_b (Point): Second point.
+        frac (float): Fraction of the way from pt_a to pt_b.
+
+    Returns:
+        Point: The slerp between pt_a and pt_b.
+
+    """
+    assert frac >= 0.0 and frac <= 1.0, "frac must be between 0 and 1"
+
+    omega = torch.acos(torch.clamp(torch.matmul(pt_a, pt_b), -1.0, 1.0))
+    pt_a_frac = torch.sin((1 - frac) * omega) / torch.sin(omega) * pt_a
+    pt_b_frac = torch.sin(frac * omega) / torch.sin(omega) * pt_b
+    return pt_a_frac + pt_b_frac
+
+
+def angle(pt_a: Point, pt_b: Point, pt_c: Point, space: Manifold, **kwargs) -> Scalar:
+    """
+    Angle B of triangle ABC, based on incident angle of geodesics AB and CB.
+    If B is along the geodesic from A to C, then the angle is pi (180 degrees).
+    If A=C, then the angle is zero.
     """
     pt_ba, converged_ba = point_along(pt_b, pt_a, space, frac=0.02, **kwargs)
     pt_bc, converged_bc = point_along(pt_b, pt_c, space, frac=0.02, **kwargs)
     if not (converged_ba and converged_bc):
         warnings.warn("point_along failed to converge; angle may be inaccurate")
     # Law of cosines using small local distances
-    d_c, d_a, d_b = space.length(pt_b, pt_ba), space.length(pt_b, pt_bc), space.length(pt_ba, pt_bc)
-    cos_b = 0.5*(d_a*d_a + d_c*d_c - d_b*d_b) / (d_a*d_c)
+    d_c, d_a, d_b = (
+        space.length(pt_b, pt_ba),
+        space.length(pt_b, pt_bc),
+        space.length(pt_ba, pt_bc),
+    )
+    cos_b = 0.5 * (d_a * d_a + d_c * d_c - d_b * d_b) / (d_a * d_c)
     return torch.arccos(torch.clip(cos_b, -1.0, 1.0))
 
 

--- a/repsim/metrics.py
+++ b/repsim/metrics.py
@@ -73,11 +73,10 @@ class AngularCKA(RepresentationMetricSpace, SPDMatrix):
 
         The main idea is to use SLERP, since AngularCKA is an arc length on the unit hypersphere of centered RDMs.
         """
-        a = center(pt_a)
-        a = a / torch.linalg.norm(a, "fro")
-        b = center(pt_b)
-        b = b / torch.linalg.norm(b, "fro")
-        return self.project(slerp(a, b, frac))
+        # Apply centering to each RDM so that inner-products alone are HSIC
+        ctr_a, ctr_b = center(pt_a), center(pt_b)
+        # Note: slerp normalizes for us, so the returned point will have unit norm even if ctr_a and ctr_b don't
+        return self.project(slerp(ctr_a, ctr_b, frac))
 
 
 class Stress(RepresentationMetricSpace, DistMatrix):

--- a/repsim/metrics.py
+++ b/repsim/metrics.py
@@ -71,9 +71,7 @@ class AngularCKA(RepresentationMetricSpace, SPDMatrix):
         """
         Compute the geodesic between two points pt_a and pt_b.
 
-        We do this by projecting both onto our hypersphere, and then
-        performing a basic arc slerp.
-
+        The main idea is to use SLERP, since AngularCKA is an arc length on the unit hypersphere of centered RDMs.
         """
         a = center(pt_a)
         a = a / torch.linalg.norm(a, "fro")
@@ -101,10 +99,9 @@ class Stress(RepresentationMetricSpace, DistMatrix):
         return True
 
     def geodesic_from(self, pt_a: Point, pt_b: Point, frac: float = 0.5):
+        """Compute the geodesic between two points pt_a and pt_b.
         """
-        Compute the geodesic between two points pt_a and pt_b.
-
-        """
+        # Stress geodesics are Euclidean in the space of RDMs
         return self.project((1 - frac) * pt_a + frac * pt_b)
 
 

--- a/repsim/metrics.py
+++ b/repsim/metrics.py
@@ -1,4 +1,5 @@
 import torch
+from repsim.geometry.trig import slerp
 from repsim.kernels import center
 from repsim.geometry.manifold import SymmetricMatrix, SPDMatrix, DistMatrix, Point, Scalar
 from repsim import pairwise
@@ -64,8 +65,17 @@ class AngularCKA(RepresentationMetricSpace, SPDMatrix):
         return True
 
     def geodesic_from(self, pt_a: Point, pt_b: Point, frac: float = 0.5):
-        raise NotImplementedError(
-            f"{self} does not have an implemented closed-form geodesic. (Check {self}._has_implemented_closed_form_geodesic())"
+        """
+        Compute the geodesic between two points pt_a and pt_b.
+
+        We do this by projecting both onto our hypersphere, and then
+        performing a basic arc slerp.
+
+        """
+        a = torch.linalg.norm(center(pt_a), 'fro')
+        b = torch.linalg.norm(center(pt_b), 'fro')
+        return self.project(
+            slerp(pt_a, pt_b, frac)
         )
 
 

--- a/repsim/metrics.py
+++ b/repsim/metrics.py
@@ -60,6 +60,14 @@ class AngularCKA(RepresentationMetricSpace, SPDMatrix):
         # Note: use clipping in case of numerical imprecision. arccos(1.00000000001) will give NaN!
         return torch.arccos(torch.clip(cka(rdm_x, rdm_y), -1.0, 1.0))
 
+    def _has_implemented_closed_form_geodesic(self) -> bool:
+        return True
+
+    def geodesic_from(self, pt_a: Point, pt_b: Point, frac: float = 0.5):
+        raise NotImplementedError(
+            f"{self} does not have an implemented closed-form geodesic. (Check {self}._has_implemented_closed_form_geodesic())"
+        )
+
 
 class Stress(RepresentationMetricSpace, DistMatrix):
     """Difference-in-pairwise-distance, AKA 'stress' from the MDS literature."""

--- a/repsim/metrics.py
+++ b/repsim/metrics.py
@@ -67,7 +67,7 @@ class AngularCKA(RepresentationMetricSpace, SPDMatrix):
     def _has_implemented_closed_form_geodesic(self) -> bool:
         return True
 
-    def geodesic_from(self, pt_a: Point, pt_b: Point, frac: float = 0.5):
+    def geodesic_from(self, pt_a: Point, pt_b: Point, frac: float = 0.5) -> Point:
         """
         Compute the geodesic between two points pt_a and pt_b.
 
@@ -79,7 +79,7 @@ class AngularCKA(RepresentationMetricSpace, SPDMatrix):
         a = a / torch.linalg.norm(a, "fro")
         b = center(pt_b)
         b = b / torch.linalg.norm(b, "fro")
-        return slerp(a, b, frac)
+        return self.project(slerp(a, b, frac))
 
 
 class Stress(RepresentationMetricSpace, DistMatrix):
@@ -96,6 +96,16 @@ class Stress(RepresentationMetricSpace, DistMatrix):
     def length(self, rdm_x: Point, rdm_y: Point) -> Scalar:
         diff_in_dist = upper_triangle(rdm_x - rdm_y)
         return torch.sqrt(torch.mean(diff_in_dist**2))
+
+    def _has_implemented_closed_form_geodesic(self) -> bool:
+        return True
+
+    def geodesic_from(self, pt_a: Point, pt_b: Point, frac: float = 0.5):
+        """
+        Compute the geodesic between two points pt_a and pt_b.
+
+        """
+        return self.project((1 - frac) * pt_a + frac * pt_b)
 
 
 class ScaleInvariantStress(RepresentationMetricSpace, DistMatrix):

--- a/repsim/metrics.py
+++ b/repsim/metrics.py
@@ -75,8 +75,10 @@ class AngularCKA(RepresentationMetricSpace, SPDMatrix):
         performing a basic arc slerp.
 
         """
-        a = torch.linalg.norm(center(pt_a), "fro")
-        b = torch.linalg.norm(center(pt_b), "fro")
+        a = center(pt_a)
+        a = a / torch.linalg.norm(a, "fro")
+        b = center(pt_b)
+        b = b / torch.linalg.norm(b, "fro")
         return slerp(a, b, frac)
 
 
@@ -177,7 +179,11 @@ def hsic(
     * note that if unbiased=True, it is possible to get small values below 0.
     """
     if k_x.size() != k_y.size():
-        raise ValueError("RDMs must have the same size, but got {} and {}".format(k_x.size(), k_y.size()))
+        raise ValueError(
+            "RDMs must have the same size, but got {} and {}".format(
+                k_x.size(), k_y.size()
+            )
+        )
     n = k_x.size()[0]
 
     if not centered:

--- a/repsim/test_compare.py
+++ b/repsim/test_compare.py
@@ -5,7 +5,6 @@ from repsim import compare, Stress, AngularCKA, AffineInvariantRiemannian, Compa
 import pytest
 
 
-
 def test_compare_random_data():
     x, y = torch.randn(10, 4), torch.randn(10, 3)
     methods = [

--- a/repsim/test_compare.py
+++ b/repsim/test_compare.py
@@ -1,7 +1,6 @@
 import torch
-from repsim import pairwise
 from repsim.kernels import Linear, Laplace, SquaredExponential
-from repsim import compare, Stress, AngularCKA, AffineInvariantRiemannian, CompareType
+from repsim import compare, Stress, AngularCKA, AffineInvariantRiemannian, ScaleInvariantStress
 import pytest
 
 
@@ -50,22 +49,49 @@ def test_riemmannian_rank_deficient():
         compare(x, y, method=unregularized, kernel_x=Linear(), kernel_y=Linear())
 
 
-def test_scale_invariance():
-    x, y = torch.randn(10, 4), torch.randn(10, 3)
-    d_x, d_y = pairwise.compare(x, type=CompareType.DISTANCE), pairwise.compare(y, type=CompareType.DISTANCE)
+def test_cka_scale_invariant():
+    _test_scale_invariant_helper(10, 4, 5, AngularCKA(10))
 
-    base_distance = compare(d_x, d_y, method="scale_invariant_stress")
-    scale_x_distance = compare(d_x*2, d_y, method="scale_invariant_stress")
-    scale_y_distance = compare(d_x, d_y/2, method="scale_invariant_stress")
 
-    assert torch.isclose(base_distance, scale_x_distance), "Failed scale invariance"
-    assert torch.isclose(base_distance, scale_y_distance), "Failed scale invariance"
-    assert torch.isclose(scale_x_distance, scale_y_distance), "Failed scale invariance"
+def test_stress_scale_variant():
+    _test_scale_variant_helper(10, 4, 5, Stress(10))
 
-    base_distance = compare(d_x, d_y, method="stress")
-    scale_x_distance = compare(d_x*2, d_y, method="stress")
-    scale_y_distance = compare(d_x, d_y/2, method="stress")
 
-    assert not torch.isclose(base_distance, scale_x_distance), "Original stress should not be scale invariant"
-    assert not torch.isclose(base_distance, scale_y_distance), "Original stress should not be scale invariant"
-    assert not torch.isclose(scale_x_distance, scale_y_distance), "Original stress should not be scale invariant"
+def test_scaleinvariantstress_scale_invariant():
+    _test_scale_invariant_helper(10, 4, 5, ScaleInvariantStress(10))
+
+
+def test_riemannian_scale_invariant():
+    _test_scale_invariant_helper(10, 4, 5, AffineInvariantRiemannian(n=10))
+
+
+def _test_scale_invariant_helper(m, nx, ny, metric):
+    x, y = torch.randn(m, nx), torch.randn(m, ny)
+    d_x = metric.to_rdm(x)
+    d_x_scaled = metric.to_rdm(x * torch.rand(size=(1,)) * 10)
+    d_y = metric.to_rdm(y)
+
+    base_distance = metric.length(d_x, d_y)
+    x_scale_x_distance = metric.length(d_x, d_x_scaled)
+    scale_x_distance = metric.length(d_x_scaled, d_y)
+
+    rtol, atol = 1e-4, 1e-5
+    assert torch.isclose(base_distance, scale_x_distance, rtol=rtol, atol=atol), "Failed scale invariance"
+    assert torch.isclose(base_distance, scale_x_distance, rtol=rtol, atol=atol), "Failed scale invariance"
+    assert torch.isclose(x_scale_x_distance, torch.zeros(1), rtol=rtol, atol=atol), "Failed scale invariance"
+
+
+def _test_scale_variant_helper(m, nx, ny, metric):
+    x, y = torch.randn(m, nx), torch.randn(m, ny)
+    d_x = metric.to_rdm(x)
+    d_x_scaled = metric.to_rdm(x * torch.rand(size=(1,)) * 10)
+    d_y = metric.to_rdm(y)
+
+    base_distance = metric.length(d_x, d_y)
+    x_scale_x_distance = metric.length(d_x, d_x_scaled)
+    scale_x_distance = metric.length(d_x_scaled, d_y)
+
+    rtol, atol = 1e-4, 1e-5
+    assert not torch.isclose(base_distance, scale_x_distance, rtol=rtol, atol=atol), "Failed scale variance"
+    assert not torch.isclose(base_distance, scale_x_distance, rtol=rtol, atol=atol), "Failed scale variance"
+    assert not torch.isclose(x_scale_x_distance, torch.zeros(1), rtol=rtol, atol=atol), "Failed scale variance"

--- a/repsim/test_geometry.py
+++ b/repsim/test_geometry.py
@@ -9,12 +9,14 @@ DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 BIG_M = 10000 if torch.cuda.is_available() else 500
 
+
 def test_geodesic_stress():
     _test_geodesic_helper(5, 3, 4, Stress(n=5))
 
 
 def test_geodesic_stress_big():
     _test_geodesic_helper(BIG_M, 100, 100, Stress(n=BIG_M))
+
 
 def test_geodesic_scale_invariant_stress():
     _test_geodesic_helper(5, 3, 4, ScaleInvariantStress(n=5))
@@ -23,6 +25,7 @@ def test_geodesic_scale_invariant_stress():
 def test_geodesic_scale_invariant_stress_big():
     _test_geodesic_helper(BIG_M, 100, 100, ScaleInvariantStress(n=BIG_M))
 
+
 def test_geodesic_cka():
     _test_geodesic_helper(5, 3, 4, AngularCKA(n=5))
 
@@ -30,12 +33,14 @@ def test_geodesic_cka():
 def test_geodesic_cka_big():
     _test_geodesic_helper(BIG_M, 100, 100, AngularCKA(n=BIG_M))
 
+
 def test_geodesic_riemann():
     _test_geodesic_helper(5, 3, 4, AffineInvariantRiemannian(n=5))
 
 
 def test_geodesic_riemann_big():
     _test_geodesic_helper(BIG_M, 100, 100, AffineInvariantRiemannian(n=BIG_M))
+
 
 def test_slerp():
     # Tests angular slerping:
@@ -67,8 +72,8 @@ def _test_geodesic_helper(m, nx, ny, metric):
 
     print(F"{metric}: {converged}")
 
-    # assert converged == OptimResult.CONVERGED, \
-    #     f"point_along failed to converge at frac={frac:.4f} using {metric}: {k_z}"
+    assert converged in [OptimResult.CONVERGED, OptimResult.NO_OPT_NEEDED], \
+        f"point_along failed to converge at frac={frac:.4f} using {metric}: {k_z}"
     assert metric.contains(k_z, atol=tolerance), \
         f"point_along failed contains() test at frac={frac:.4f}  using {metric}, {metric}"
     assert np.isclose(dist_xy, dist_xz + dist_zy, atol=tolerance), \

--- a/repsim/test_geometry.py
+++ b/repsim/test_geometry.py
@@ -58,8 +58,9 @@ def _test_geodesic_helper(m, nx, ny, metric):
 
     # Note: we'll insist on computing the midpoint with tolerance/10, then do later checks up to tolerance. This just
     # gives a slight margin.
-    frac, tolerance = np.random.rand(1)[0], 1e-3
-    k_z, converged = point_along(k_x, k_y, metric, frac=frac, pt_tol=tolerance/10, fn_tol=1e-6)
+    frac, tolerance = np.random.rand(1)[0], 1.5e-3
+    vals = point_along(k_x, k_y, metric, frac=frac, pt_tol=tolerance/10, fn_tol=1e-6)
+    k_z, converged = vals
     dist_xy = metric.length(k_x, k_y)
     dist_xz = metric.length(k_x, k_z)
     dist_zy = metric.length(k_z, k_y)

--- a/repsim/test_geometry.py
+++ b/repsim/test_geometry.py
@@ -2,37 +2,49 @@ import torch
 import numpy as np
 from repsim import Stress, ScaleInvariantStress, AngularCKA, AffineInvariantRiemannian
 from repsim.geometry.optimize import OptimResult
-from repsim.geometry.trig import angle
+from repsim.geometry.trig import angle, slerp
 from repsim.geometry.geodesic import point_along, project_along
 
+DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+BIG_M = 10000 if torch.cuda.is_available() else 500
 
 def test_geodesic_stress():
     _test_geodesic_helper(5, 3, 4, Stress(n=5))
 
 
 def test_geodesic_stress_big():
-    _test_geodesic_helper(10000, 100, 100, Stress(n=10000))
+    _test_geodesic_helper(BIG_M, 100, 100, Stress(n=BIG_M))
 
 def test_geodesic_scale_invariant_stress():
     _test_geodesic_helper(5, 3, 4, ScaleInvariantStress(n=5))
 
 
 def test_geodesic_scale_invariant_stress_big():
-    _test_geodesic_helper(10000, 100, 100, ScaleInvariantStress(n=10000))
+    _test_geodesic_helper(BIG_M, 100, 100, ScaleInvariantStress(n=BIG_M))
 
 def test_geodesic_cka():
     _test_geodesic_helper(5, 3, 4, AngularCKA(n=5))
 
 
 def test_geodesic_cka_big():
-    _test_geodesic_helper(10000, 100, 100, AngularCKA(n=10000))
+    _test_geodesic_helper(BIG_M, 100, 100, AngularCKA(n=BIG_M))
 
 def test_geodesic_riemann():
     _test_geodesic_helper(5, 3, 4, AffineInvariantRiemannian(n=5))
 
 
 def test_geodesic_riemann_big():
-    _test_geodesic_helper(10000, 100, 100, AffineInvariantRiemannian(n=10000))
+    _test_geodesic_helper(BIG_M, 100, 100, AffineInvariantRiemannian(n=BIG_M))
+
+def test_slerp():
+    # Tests angular slerping:
+    assert slerp(torch.tensor([0, 0, 1]), torch.tensor([0, 0, 1]), 0.5).allclose(torch.tensor([0, 0, 1]))
+    assert slerp(torch.tensor([0, 0, 1]), torch.tensor([0, 0, 1]), 0).allclose(torch.tensor([0, 0, 1]))
+    assert slerp(torch.tensor([0, 0, 1]), torch.tensor([0, 0, 1]), 1).allclose(torch.tensor([0, 0, 1]))
+
+    assert slerp(torch.tensor([0, 0, 1]), torch.tensor([0, 0, 2]), 1).allclose(torch.tensor([0, 0, 2]))
+    assert slerp(torch.tensor([0, 0, 1]), torch.tensor([0, 0, 2]), 0.5).allclose(torch.tensor([0, 0, 1.5]))
 
 
 def _test_geodesic_helper(m, nx, ny, metric):
@@ -73,7 +85,7 @@ def test_projection_stress():
 
 
 def test_projection_stress_big():
-    _test_projection_helper(10000, 100, 100, 100, Stress(n=10000))
+    _test_projection_helper(BIG_M, 100, 100, 100, Stress(n=BIG_M))
 
 
 def test_projection_scale_invariant_stress():
@@ -81,7 +93,7 @@ def test_projection_scale_invariant_stress():
 
 
 def test_projection_scale_invariant_stress_big():
-    _test_projection_helper(10000, 100, 100, 100, ScaleInvariantStress(n=10000))
+    _test_projection_helper(BIG_M, 100, 100, 100, ScaleInvariantStress(n=BIG_M))
 
 
 def test_projection_cka():
@@ -89,7 +101,7 @@ def test_projection_cka():
 
 
 def test_projection_cka_big():
-    _test_projection_helper(10000, 100, 100, 100, AngularCKA(n=10000))
+    _test_projection_helper(BIG_M, 100, 100, 100, AngularCKA(n=BIG_M))
 
 
 def test_projection_riemann():
@@ -97,7 +109,7 @@ def test_projection_riemann():
 
 
 def test_projection_riemann_big():
-    _test_projection_helper(10000, 100, 100, 100, AffineInvariantRiemannian(n=10000))
+    _test_projection_helper(BIG_M, 100, 100, 100, AffineInvariantRiemannian(n=BIG_M))
 
 
 def _test_projection_helper(m, nx, ny, nz, metric):

--- a/repsim/test_geometry.py
+++ b/repsim/test_geometry.py
@@ -58,7 +58,7 @@ def _test_geodesic_helper(m, nx, ny, metric):
 
     # Note: we'll insist on computing the midpoint with tolerance/10, then do later checks up to tolerance. This just
     # gives a slight margin.
-    frac, tolerance = np.random.rand(1)[0], 1.5e-3
+    frac, tolerance = np.random.rand(1)[0], 1e-2
     vals = point_along(k_x, k_y, metric, frac=frac, pt_tol=tolerance/10, fn_tol=1e-6)
     k_z, converged = vals
     dist_xy = metric.length(k_x, k_y)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ python setup.py sdist
 twine upload dist/*
 """
 
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:


### PR DESCRIPTION
This PR adds three main novel features:

- [x] acosCKA geodesics in closed form, to avoid using the solver
- [x] Stress geodesics in closed form, to avoid using the solver
- [x] Updates to the test suite to reduce the size of the big matrices based upon whether the machine has CUDA available.

Together, this should make unittests run successfully on GitHub actions, and greatly reduce overall runtime, per conversations with @wrongu.